### PR TITLE
BUG-747: Read media urls (still image, rendition sources etc.) from a live API

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,11 @@
 zeit.content.video changes
 ==========================
 
-2.9.1 (unreleased)
+3.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-747: Read media urls (still image, rendition sources etc.) from
+  a live API, since they are not infinitely valid (at least for Brightcove)
 
 
 2.9.0 (2017-10-04)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.content.video',
-    version='2.9.1.dev0',
+    version='3.0.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/content/video/browser/video.py
+++ b/src/zeit/content/video/browser/video.py
@@ -29,7 +29,7 @@ class Base(zeit.push.browser.form.SocialBase,
         # remaining:
         '__name__',
         'created', 'date_first_released', 'modified', 'expires',
-        'thumbnail', 'video_still', 'flv_url', 'authorships')
+        'thumbnail', 'video_still', 'authorships')
 
     field_groups = (
         gocept.form.grouped.Fields(

--- a/src/zeit/content/video/interfaces.py
+++ b/src/zeit/content/video/interfaces.py
@@ -58,11 +58,6 @@ class IVideo(IVideoContent):
         required=False,
         readonly=True)
 
-    flv_url = zope.schema.URI(
-        title=_('URI of the video file'),
-        required=False,
-        readonly=True)
-
     renditions = zope.schema.Tuple(
         title=_("Renditions of the Video"),
         required=False,

--- a/src/zeit/content/video/interfaces.py
+++ b/src/zeit/content/video/interfaces.py
@@ -43,6 +43,10 @@ class IVideoRendition(zope.interface.interfaces.IInterface):
 
 class IVideo(IVideoContent):
 
+    external_id = zope.schema.TextLine(
+        title=_('External ID'),
+        readonly=True)
+
     has_recensions = zope.schema.Bool(
         title=_('Has recension content'),
         default=False)

--- a/src/zeit/content/video/interfaces.py
+++ b/src/zeit/content/video/interfaces.py
@@ -143,3 +143,16 @@ class IVideoAsset(zope.interface.Interface):
         description=_("Drag a video here"),
         required=False,
         source=videoOrPlaylistSource)
+
+
+class IPlayer(zope.interface.Interface):
+    """Extension point to access media information, e.g. still image or
+    video source URLs, since those may be volatile.
+    """
+
+    def get_video(id):
+        """Must return a dict with at least the following keys:
+        * thumbnail: str
+        * video_still: str
+        * renditions: list of IVideoRendition
+        """

--- a/src/zeit/content/video/interfaces.py
+++ b/src/zeit/content/video/interfaces.py
@@ -69,6 +69,9 @@ class IVideo(IVideoContent):
         )
     )
 
+    highest_rendition_url = zope.interface.Attribute(
+        'URL of the rendition with the highest resolution')
+
     serie = zope.schema.Choice(
         title=_("Serie"),
         source=SerieSource(),

--- a/src/zeit/content/video/solr.py
+++ b/src/zeit/content/video/solr.py
@@ -20,12 +20,6 @@ class Index(object):
         return getattr(self.__class__, 'grokcore.component.directive.name')
 
 
-class FLVURLIndex(Index, grokcore.component.GlobalUtility):
-
-    grokcore.component.name('h264_url')
-    attribute = 'flv_url'
-
-
 class BannerIndex(Index, grokcore.component.GlobalUtility):
 
     grokcore.component.name('banner')

--- a/src/zeit/content/video/tests/test_browser.py
+++ b/src/zeit/content/video/tests/test_browser.py
@@ -1,11 +1,14 @@
 import plone.testing
-import zeit.push.interfaces
+import urllib2
+import zeit.cms.browser.interfaces
 import zeit.cms.testing
 import zeit.cms.workflow.interfaces
 import zeit.content.video.testing
+import zeit.push.interfaces
 import zeit.push.testing
 import zope.component
-import zope.security.management
+import zope.component
+import zope.publisher.browser
 
 
 class TestThumbnail(zeit.cms.testing.BrowserTestCase):
@@ -13,10 +16,15 @@ class TestThumbnail(zeit.cms.testing.BrowserTestCase):
     layer = zeit.content.video.testing.LAYER
 
     def test_view_on_video_should_redirect_to_video_thumbnail_url(self):
-        import urllib2
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        player.get_video.return_value = {
+            'renditions': (),
+            'thumbnail': 'http://thumbnailurl',
+            'video_still': None,
+        }
         factory = zeit.content.video.testing.video_factory(self)
-        video = factory.next()
-        video.thumbnail = 'http://thumbnailurl'
+        factory.next()
         factory.next()
         self.browser.open('http://localhost/++skin++vivi/repository/video/')
         self.browser.mech_browser.set_handle_redirect(False)
@@ -27,12 +35,15 @@ class TestThumbnail(zeit.cms.testing.BrowserTestCase):
                          e.exception.hdrs.get('location'))
 
     def test_url_of_view_on_video_should_return_thumbnail_url(self):
-        import zope.publisher.browser
-        import zope.component
-        import zeit.cms.browser.interfaces
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        player.get_video.return_value = {
+            'renditions': (),
+            'thumbnail': 'http://thumbnailurl',
+            'video_still': None,
+        }
         factory = zeit.content.video.testing.video_factory(self)
-        video = factory.next()
-        video.thumbnail = 'http://thumbnailurl'
+        factory.next()
         video = factory.next()
 
         request = zope.publisher.browser.TestRequest(
@@ -46,7 +57,6 @@ class TestThumbnail(zeit.cms.testing.BrowserTestCase):
         self.assertEqual(url, 'http://thumbnailurl')
 
     def test_view_on_playlist_should_redirect_to_playlist_thumbnail_url(self):
-        import urllib2
         factory = zeit.content.video.testing.playlist_factory(self)
         playlist = factory.next()
         playlist.thumbnail = 'http://thumbnailurl'
@@ -60,9 +70,6 @@ class TestThumbnail(zeit.cms.testing.BrowserTestCase):
                          e.exception.hdrs.get('location'))
 
     def test_url_of_view_on_playlist_should_return_thumbnail_url(self):
-        import zope.publisher.browser
-        import zope.component
-        import zeit.cms.browser.interfaces
         factory = zeit.content.video.testing.playlist_factory(self)
         playlist = factory.next()
         playlist.thumbnail = 'http://thumbnailurl'
@@ -84,10 +91,15 @@ class TestStill(zeit.cms.testing.BrowserTestCase):
     layer = zeit.content.video.testing.LAYER
 
     def test_preview_view_on_video_should_redirect_to_still_url(self):
-        import urllib2
         factory = zeit.content.video.testing.video_factory(self)
-        video = factory.next()
-        video.video_still = 'http://stillurl'
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        player.get_video.return_value = {
+            'renditions': (),
+            'thumbnail': None,
+            'video_still': 'http://stillurl',
+        }
+        factory.next()
         factory.next()
         self.browser.open('http://localhost/++skin++vivi/repository/video/')
         self.browser.mech_browser.set_handle_redirect(False)
@@ -98,12 +110,15 @@ class TestStill(zeit.cms.testing.BrowserTestCase):
                          e.exception.hdrs.get('location'))
 
     def test_url_of_preview_view_on_video_should_return_still_url(self):
-        import zope.publisher.browser
-        import zope.component
-        import zeit.cms.browser.interfaces
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        player.get_video.return_value = {
+            'renditions': (),
+            'thumbnail': None,
+            'video_still': 'http://stillurl',
+        }
         factory = zeit.content.video.testing.video_factory(self)
-        video = factory.next()
-        video.video_still = 'http://stillurl'
+        factory.next()
         video = factory.next()
 
         request = zope.publisher.browser.TestRequest(

--- a/src/zeit/content/video/tests/test_solr.py
+++ b/src/zeit/content/video/tests/test_solr.py
@@ -1,6 +1,7 @@
 import zeit.solr.interfaces
 import zope.component
 import zeit.content.video.testing
+import mock
 
 
 class TestSolrIndexing(zeit.content.video.testing.TestCase):
@@ -39,3 +40,14 @@ class TestSolrIndexing(zeit.content.video.testing.TestCase):
         video = test.next()
         video.banner_id = '32kcdc'
         test.send('32kcdc')
+
+    def test_thumbnail_url_should_be_indexed(self):
+        test = self.get_test('thumbnail')
+        test.next()
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        player.get_video.return_value = {
+            'renditions': (),
+            'thumbnail': 'http://thumbnailurl',
+            'video_still': None}
+        test.send('http://thumbnailurl')

--- a/src/zeit/content/video/tests/test_solr.py
+++ b/src/zeit/content/video/tests/test_solr.py
@@ -26,13 +26,7 @@ class TestSolrIndexing(zeit.content.video.testing.TestCase):
         element_add = self.solr.update_raw.call_args_list[0][0][0]
         self.assertEquals(
             [expected],
-            element_add.xpath("/add/doc/field[@name='%s']"% name))
-
-    def test_flv_url_should_be_indexed(self):
-        test = self.get_test('h264_url')
-        video = test.next()  # get prepared test object
-        video.flv_url = u'http://flvurl'
-        test.send(u'http://flvurl')  # Send expected result
+            element_add.xpath("/add/doc/field[@name='%s']" % name))
 
     def test_banner_should_be_indexed(self):
         test = self.get_test('banner')

--- a/src/zeit/content/video/video.py
+++ b/src/zeit/content/video/video.py
@@ -72,7 +72,7 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
     zeit.cms.content.dav.mapProperties(
         zeit.content.video.interfaces.IVideo,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        ('has_recensions', 'expires', 'video_still', 'flv_url', 'thumbnail',
+        ('has_recensions', 'expires', 'video_still', 'thumbnail',
          'video_still_copyright'))
 
     zeit.cms.content.dav.mapProperties(

--- a/src/zeit/content/video/video.py
+++ b/src/zeit/content/video/video.py
@@ -1,11 +1,11 @@
 from zeit.cms.i18n import MessageFactory as _
+from zope.cachedescriptors.property import Lazy as cachedproperty
 import grokcore.component as grok
 import lxml.objectify
 import pkg_resources
 import zeit.cms.content.dav
 import zeit.cms.content.interfaces
 import zeit.cms.content.metadata
-import zeit.cms.content.property
 import zeit.cms.content.reference
 import zeit.cms.interfaces
 import zeit.cms.type
@@ -13,27 +13,6 @@ import zeit.content.video.interfaces
 import zeit.push.interfaces
 import zeit.workflow.dependency
 import zope.interface
-
-
-class RenditionsProperty(zeit.cms.content.property.MultiPropertyBase):
-
-    def _element_factory(self, node, tree):
-        result = VideoRendition()
-        result.url = node.get('url')
-        if node.get('frame_width'):
-            result.frame_width = int(node.get('frame_width'))
-        if node.get('video_duration'):
-            result.video_duration = int(node.get('video_duration'))
-        return result
-
-    def _node_factory(self, entry, tree):
-        node = lxml.objectify.E.rendition()
-        node.set('url', entry.url)
-        if getattr(entry, 'frame_width', None):
-            node.set('frame_width', str(entry.frame_width))
-        if getattr(entry, 'video_duration', None):
-            node.set('video_duration', str(entry.video_duration))
-        return node
 
 
 class AuthorshipsProperty(zeit.cms.content.reference.ReferenceProperty):
@@ -72,8 +51,7 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
     zeit.cms.content.dav.mapProperties(
         zeit.content.video.interfaces.IVideo,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        ('has_recensions', 'expires', 'video_still', 'thumbnail',
-         'video_still_copyright'))
+        ('has_recensions', 'expires', 'video_still_copyright'))
 
     zeit.cms.content.dav.mapProperties(
         zeit.content.video.interfaces.IVideo,
@@ -88,6 +66,10 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
         'http://namespaces.zeit.de/CMS/brightcove', 'id')
 
     @property
+    def renditions(self):
+        return self._player_data['renditions']
+
+    @property
     def highest_rendition_url(self):
         if not self.renditions:
             return None
@@ -95,10 +77,23 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
         return getattr(high, 'url', '')
 
     @property
+    def thumbnail(self):
+        return self._player_data['thumbnail']
+
+    @property
+    def video_still(self):
+        return self._player_data['video_still']
+
+    @cachedproperty
+    def _player_data(self):
+        player = zope.component.getUtility(
+            zeit.content.video.interfaces.IPlayer)
+        return player.get_video(self.external_id)
+
+    @property
     def teaserTitle(self):
         return self.title
 
-    renditions = RenditionsProperty('.head.renditions.rendition')
     authorships = AuthorshipsProperty(
         str(zeit.cms.content.metadata.CommonMetadata.authorships.path),
         zeit.cms.content.metadata.CommonMetadata.authorships.xml_reference_name

--- a/src/zeit/content/video/video.py
+++ b/src/zeit/content/video/video.py
@@ -87,6 +87,13 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
     # a particular external video service.
 
     @property
+    def highest_rendition_url(self):
+        if not self.renditions:
+            return None
+        high = sorted(self.renditions, key=lambda r: r.frame_width).pop()
+        return getattr(high, 'url', '')
+
+    @property
     def teaserTitle(self):
         return self.title
 

--- a/src/zeit/content/video/video.py
+++ b/src/zeit/content/video/video.py
@@ -82,9 +82,10 @@ class Video(zeit.cms.content.metadata.CommonMetadata):
 
     id_prefix = 'vid'
 
-    # Note: zeit.brightcove will inject a brightcove_id property here in order
-    # to avoid a package dependency of zeit.content.video on the interface to
-    # a particular external video service.
+    external_id = zeit.cms.content.dav.DAVProperty(
+        zeit.content.video.interfaces.IVideo['external_id'],
+        # BBB This field used to be injected into here from zeit.brightcove
+        'http://namespaces.zeit.de/CMS/brightcove', 'id')
 
     @property
     def highest_rendition_url(self):


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.brightcove/pull/15