### PR TITLE
BUG-841: Disable setting channel from ressort for videos/playlists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.video changes
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-841: Disable setting channel from ressort for videos/playlists
 
 
 3.0.1 (2017-12-05)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'plone.testing',
         'pytz',
         'setuptools',
-        'zeit.cms >= 3.0.dev0',
+        'zeit.cms >= 3.3.0.dev0',
         'zeit.connector',
         'zeit.push >= 1.21.0.dev0',
         'zeit.solr>=2.2.0.dev0',

--- a/src/zeit/content/video/interfaces.py
+++ b/src/zeit/content/video/interfaces.py
@@ -4,7 +4,8 @@ import zope.schema
 
 
 class IVideoContent(zeit.cms.content.interfaces.ICommonMetadata,
-                    zeit.cms.content.interfaces.IXMLContent):
+                    zeit.cms.content.interfaces.IXMLContent,
+                    zeit.cms.content.interfaces.ISkipDefaultChannel):
     """Video like content.
 
     This could be a video or a playlist.


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.cms/pull/74